### PR TITLE
Serverless Website Component: Added CloudFront Support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ myWebsite:
     region: us-east-1 # The AWS region to deploy your website into
     bucketName: myBucket # (Optional) The Bucket name where `src` files/folder will be upload. 
                          # If not provided, it will create random bucket name and upload `src` files
+    cloudFront: # (Optional)
+        waitForCreateDistribution: true  # (Optional) wait for create cloudfront distrubution to complete
+        waitForUpdateDistribution: false # (Optional) wait for update cloudfront distrubution to complete
+        customOrigin: true # (Optional)  wait for custom origin to avoid s3 bucket redirect during cloudfront creation
     env: # Environment variables to include in a 'env.js' file with your uploaded code.
       API_URL: https://api.com
       

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ myWebsite:
     bucketName: myBucket # (Optional) The Bucket name where `src` files/folder will be upload. 
                          # If not provided, it will create random bucket name and upload `src` files
     cloudFront: # (Optional)
-        waitForCreateDistribution: true  # (Optional) wait for create cloudfront distrubution to complete
-        waitForUpdateDistribution: false # (Optional) wait for update cloudfront distrubution to complete
+        waitForCreateDistribution: true  # (Optional) wait for create cloudfront distribution to complete
+        waitForUpdateDistribution: false # (Optional) wait for update cloudfront distribution to complete
         customOrigin: true # (Optional)  wait for custom origin to avoid s3 bucket redirect during cloudfront creation
     env: # Environment variables to include in a 'env.js' file with your uploaded code.
       API_URL: https://api.com

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@serverless/website",
-  "version": "3.0.9",
+  "name": "@ublend-npm/serverless-website-component",
+  "version": "0.0.1",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"
@@ -10,7 +10,7 @@
     "lint": "eslint . --fix --cache"
   },
   "author": "Serverless, Inc.",
-  "license": "Apache",
+  "license": "UNLICENSED",
   "dependencies": {
     "@serverless/aws-s3": "^2.0.0",
     "@serverless/core": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/website",
-  "version": "3.0.2",
+  "version": "3.0.9",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"
@@ -12,9 +12,9 @@
   "author": "Serverless, Inc.",
   "license": "Apache",
   "dependencies": {
-    "@serverless/aws-s3": "^2.0.7",
+    "@serverless/aws-s3": "^2.0.0",
     "@serverless/core": "^1.0.0",
-    "@serverless/domain": "^2.0.6",
+    "@serverless/domain": "^2.0.0",
     "aws-sdk": "^2.499.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@ublend-npm/serverless-website-component",
-  "version": "0.0.1",
+  "name": "@serverless/website",
+  "version": "3.0.2",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"
@@ -10,11 +10,11 @@
     "lint": "eslint . --fix --cache"
   },
   "author": "Serverless, Inc.",
-  "license": "UNLICENSED",
+  "license": "Apache",
   "dependencies": {
-    "@serverless/aws-s3": "^2.0.0",
+    "@serverless/aws-s3": "^2.0.7",
     "@serverless/core": "^1.0.0",
-    "@serverless/domain": "^2.0.0",
+    "@serverless/domain": "^2.0.6",
     "aws-sdk": "^2.499.0"
   },
   "devDependencies": {

--- a/serverless.js
+++ b/serverless.js
@@ -20,7 +20,9 @@ class Website extends Component {
    * Types
    */
 
-  types() { return types }
+  types() {
+    return types
+  }
 
   /*
    * Default
@@ -119,7 +121,11 @@ class Website extends Component {
         subdomains: {}
       }
 
-      domainInputs.subdomains[subdomain] = { url: this.state.url }
+      domainInputs.subdomains[subdomain] = {
+        url: this.state.url,
+        bucketName: this.state.bucketName,
+        cloudFront: inputs.cloudFront
+      }
       const domainOutputs = await domain(domainInputs)
 
       outputs.domain = domainOutputs.domains[0]


### PR DESCRIPTION
This PR is the continuation of other PR at `serverless/domain` https://github.com/serverless-components/domain/pull/6

This changeset passes s3 bucket name and CloudFront information to `serverless/domain` component.

For the consumer,  there will be few CloudFront properties 

```yaml
myWebsite:
  component: "@serverless/website"
  inputs:
    cloudFront: # (Optional)
        waitForCreateDistribution: true  # (Optional) wait for create CloudFront distribution to complete
        waitForUpdateDistribution: false # (Optional) wait for update CloudFront distribution to complete
        customOrigin: true # (Optional)  wait for custom origin to avoid s3 bucket redirect during cloudfront creation
```
`CustomOrigin` is required to avoid CloudFront url redirection to s3 website redirection for initial 30-40 minutes.